### PR TITLE
add support for multiple states.

### DIFF
--- a/dist/bespoke-state.js
+++ b/dist/bespoke-state.js
@@ -10,8 +10,15 @@
 
 	bespoke.plugins.state = function(deck) {
 		var modifyState = function(method, event) {
-			var state = event.slide.getAttribute('data-bespoke-state');
-			state && deck.parent.classList[method](state);
+			var attr = event.slide.getAttribute('data-bespoke-state') || '',
+				states = attr.split(' ');
+
+			for (var i = 0, l = states.length; i < l; i++) {
+				/* Need to do this since splitting an empty string results in
+				 * an array containing an empty string. */
+				if (!states[i]) continue;
+				deck.parent.classList[method](states[i]);
+			}
 		};
 
 		deck.on('activate', modifyState.bind(null, 'add'));

--- a/dist/bespoke-state.min.js
+++ b/dist/bespoke-state.min.js
@@ -1,2 +1,2 @@
 /*! bespoke-state v0.1.0 © 2013 Mark Dalgleish, Licensed MIT */
-(function(e){e.plugins.state=function(e){var t=function(t,n){var r=n.slide.getAttribute("data-bespoke-state");r&&e.parent.classList[t](r)};e.on("activate",t.bind(null,"add")),e.on("deactivate",t.bind(null,"remove"))}})(bespoke);
+(function(e){e.plugins.state=function(e){var t=function(t,n){var r=n.slide.getAttribute("data-bespoke-state")||"",i=r.split(" ");for(var s=0,o=i.length;s<o;s++){if(!i[s])continue;e.parent.classList[t](i[s])}};e.on("activate",t.bind(null,"add")),e.on("deactivate",t.bind(null,"remove"))}})(bespoke);

--- a/specs/bespoke-state_spec.js
+++ b/specs/bespoke-state_spec.js
@@ -18,7 +18,8 @@
 				for (var i = 0; i < NO_OF_SLIDES; i++) {
 					slides.push(document.createElement(SLIDE_TAG));
 					if (i !== NON_STATE_SLIDE_INDEX) {
-						slides[i].setAttribute('data-bespoke-state', 'state-' + i);
+						slides[i].setAttribute('data-bespoke-state',
+												'stateA'+i +' stateB'+i);
 					}
 					article.appendChild(slides[i]);
 				}
@@ -43,7 +44,8 @@
 			});
 
 			it("should add the state to the parent", function() {
-				expect(deck.parent.classList.contains('state-1')).toBe(true);
+				expect(deck.parent.classList.contains('stateA1')).toBe(true);
+				expect(deck.parent.classList.contains('stateB1')).toBe(true);
 			});
 
 			describe("when another slide is activated", function() {
@@ -53,7 +55,8 @@
 				});
 
 				it("should remove the state from the parent", function() {
-					expect(deck.parent.classList.contains('state-1')).toBe(false);
+					expect(deck.parent.classList.contains('stateA1')).toBe(false);
+					expect(deck.parent.classList.contains('stateB1')).toBe(false);
 				});
 
 			});

--- a/src/bespoke-state.js
+++ b/src/bespoke-state.js
@@ -2,8 +2,15 @@
 
 	bespoke.plugins.state = function(deck) {
 		var modifyState = function(method, event) {
-			var state = event.slide.getAttribute('data-bespoke-state');
-			state && deck.parent.classList[method](state);
+			var attr = event.slide.getAttribute('data-bespoke-state') || '',
+				states = attr.split(' ');
+
+			for (var i = 0, l = states.length; i < l; i++) {
+				/* Need to do this since splitting an empty string results in
+				 * an array containing an empty string. */
+				if (!states[i]) continue;
+				deck.parent.classList[method](states[i]);
+			}
 		};
 
 		deck.on('activate', modifyState.bind(null, 'add'));


### PR DESCRIPTION
- modify tests to fit the multistate case.
- regenerate dist/

The used classList API only allows `add()` being called with a single
class. Therefore if your data-bespoke-state attribute contains multiple
classes, it throws an exception.

When might this happen? For example when you are having transitions
isolated into own classes, so we can swap them between slides.
