### PR TITLE
Add "main" key to package.json to make it npm installable

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "Mark Dalgleish",
     "url": "http://markdalgleish.com"
   },
+  "main": "./dist/bespoke-state.js",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
Consider also releasing it on npm so anyone who use browserify and other CommonJS bundlers can use it easily.
